### PR TITLE
Stream deletion API

### DIFF
--- a/client.go
+++ b/client.go
@@ -414,8 +414,8 @@ func (c *client) CreateStream(ctx context.Context, subject, name string, options
 	return err
 }
 
-// DeleteStream deletes a stream. Subject is the NATS subject the stream is
-// attached to, and name is the stream identifier, unique per subject.
+// DeleteStream deletes a stream. Name is the stream identifier, globally
+// unique.
 func (c *client) DeleteStream(ctx context.Context, name string) error {
 	req := &proto.DeleteStreamRequest{
 		Name: name,

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.13
 require (
 	github.com/Workiva/go-datastructures v1.0.51 // indirect
 	github.com/golang/protobuf v1.3.4
-	github.com/liftbridge-io/liftbridge v1.0.0-beta
-	github.com/liftbridge-io/liftbridge-api v1.0.0-beta
+	github.com/liftbridge-io/liftbridge v1.0.0-beta.0.20200307013051-3683ddf64c2c
+	github.com/liftbridge-io/liftbridge-api v1.0.0-beta.0.20200312161101-bf413bcbd765
 	github.com/liftbridge-io/nats-on-a-log v0.0.0-20200303015016-68120bc11e03 // indirect
 	github.com/nats-io/nats-server v1.4.1
 	github.com/nats-io/nats.go v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -147,6 +147,8 @@ github.com/liftbridge-io/liftbridge v0.0.0-20200118200014-2e716da78b8a h1:S3PsQK
 github.com/liftbridge-io/liftbridge v0.0.0-20200118200014-2e716da78b8a/go.mod h1:j3eqt63LZefajwMwcLeYtS/BEFHqPXA7ogvjJCsB1h8=
 github.com/liftbridge-io/liftbridge v1.0.0-beta h1:niS6Z6u8COgo68nTNr07uIoFnhwInoymV3v3tsiztBE=
 github.com/liftbridge-io/liftbridge v1.0.0-beta/go.mod h1:PVOWcc0V8g2BgfAiq2Ak8OfuNJIskpK1XF4sqfszScc=
+github.com/liftbridge-io/liftbridge v1.0.0-beta.0.20200307013051-3683ddf64c2c h1:MhEQ+HnVEUTNUV0WIX8sG3k6RdtvHDJTR09nGKQYVfw=
+github.com/liftbridge-io/liftbridge v1.0.0-beta.0.20200307013051-3683ddf64c2c/go.mod h1:iKRlN6s4BSmFtm/qv7pEE/Z/N0vX7a4KPv5qKFkb0fc=
 github.com/liftbridge-io/liftbridge-api v0.0.0-20190910222614-5694b15f251d/go.mod h1:6IFEFZ4ncnOgeDVjSt0vh1lKNhlJ5YT9xnG1eRa9LC8=
 github.com/liftbridge-io/liftbridge-api v0.0.0-20200118015119-3db283f59b10 h1:k10Bg5EQTc/B5dTSU8cPW4Y0OkBlnMFuFGZwRmrPvJ4=
 github.com/liftbridge-io/liftbridge-api v0.0.0-20200118015119-3db283f59b10/go.mod h1:6IFEFZ4ncnOgeDVjSt0vh1lKNhlJ5YT9xnG1eRa9LC8=
@@ -154,6 +156,8 @@ github.com/liftbridge-io/liftbridge-api v1.0.0-alpha h1:NwtHTgIdYNQXkLdmLHm9rguN
 github.com/liftbridge-io/liftbridge-api v1.0.0-alpha/go.mod h1:6IFEFZ4ncnOgeDVjSt0vh1lKNhlJ5YT9xnG1eRa9LC8=
 github.com/liftbridge-io/liftbridge-api v1.0.0-beta h1:5ifm6YuMnakZH1XlkeWfXeZW6ygKpTsjZcUaQA6Nts8=
 github.com/liftbridge-io/liftbridge-api v1.0.0-beta/go.mod h1:6IFEFZ4ncnOgeDVjSt0vh1lKNhlJ5YT9xnG1eRa9LC8=
+github.com/liftbridge-io/liftbridge-api v1.0.0-beta.0.20200312161101-bf413bcbd765 h1:ainowikclNBfxawwBRZjm1ZF2GXIqTArUO2S2Vd+UA0=
+github.com/liftbridge-io/liftbridge-api v1.0.0-beta.0.20200312161101-bf413bcbd765/go.mod h1:6IFEFZ4ncnOgeDVjSt0vh1lKNhlJ5YT9xnG1eRa9LC8=
 github.com/liftbridge-io/liftbridge-grpc v0.0.0-20190829220806-66e3ee4b7943/go.mod h1:ObGO38WdO4ldLsa2oUFcultUk0rggc+yZWcBb7qjnDI=
 github.com/liftbridge-io/liftbridge-grpc v0.0.0-20190910222614-5694b15f251d/go.mod h1:ObGO38WdO4ldLsa2oUFcultUk0rggc+yZWcBb7qjnDI=
 github.com/liftbridge-io/nats-on-a-log v0.0.0-20180718011723-80d0727461af/go.mod h1:4tC6R+N3facyfCwDuuuLkFF/25ceiZEwoQUzIez2dVo=


### PR DESCRIPTION
This PR adds an RPC so that clients can ask for the deletion of a stream. All corresponding partitions will also be removed, as well as their persistent storage.

Note that Liftbridge clients that have subscribed to a stream that will get deleted do not receive any notification.